### PR TITLE
Capacity change + overflow mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-broadcast"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/smol-rs/async-broadcast"
 documentation = "https://docs.rs/async-broadcast"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,10 +1,14 @@
-use std::sync::mpsc;
+use std::{sync::mpsc, thread::sleep, time::Duration};
 
 use futures_util::stream::StreamExt;
 use async_broadcast::*;
 
 use easy_parallel::Parallel;
 use futures_lite::future::block_on;
+
+fn ms(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
 
 #[test]
 fn basic_sync() {
@@ -94,6 +98,7 @@ fn parallel_async() {
     Parallel::new()
         .add(move || block_on(async move {
             sender_sync_recv.recv().unwrap();
+            sleep(ms(5));
 
             s1.broadcast(7).await.unwrap();
             s2.broadcast(8).await.unwrap();
@@ -120,6 +125,7 @@ fn parallel_async() {
             assert_eq!(r2.recv().await.unwrap(), 8);
 
             receiver_sync_recv.recv().unwrap();
+            sleep(ms(5));
             assert_eq!(r1.next().await.unwrap(), 9);
             assert_eq!(r2.next().await.unwrap(), 9);
 


### PR DESCRIPTION
This PR adds:

* ~~Add a notion of message priority (used by the other two API)~~. In the end, this will just complicate things and I don't see people wanting to delete newer messages on channel shrink
* Ability to set capacity after the channel has been created. If the new capacity is smaller than the current length, messages are dropped to correct the situation. The messages are dropped starting from oldest to newest.
* Overflow mode setting: When enabled, broadcasting a message to a full channel always succeeds, by removal of the oldest message from the channel. The removed message is handed over the `Sender::{try_broadcast, broadcast}` caller.