### PR TITLE
Avoid clode for the last recv of a message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ authors = [
     "Zeeshan Ali <zeeshanak@gnome.org>",
 ]
 
+[[bench]]
+harness = false
+name = "broadcast_bench"
+
 [features]
 
 [dependencies]
@@ -23,6 +27,7 @@ futures-core = "0.3.14"
 easy-parallel = "3.1.0"
 
 [dev-dependencies]
+criterion = "0.3"
 doc-comment = "0.3.3"
 futures-lite = "1.11.3"
 futures-util = "0.3.14"

--- a/benches/broadcast_bench.rs
+++ b/benches/broadcast_bench.rs
@@ -1,0 +1,33 @@
+use async_broadcast::broadcast;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures_lite::future::block_on;
+pub fn broadcast_and_recv(c: &mut Criterion) {
+    let (s, mut r1) = broadcast(1);
+
+    let mut n = 0;
+    c.bench_function("1 -> 1", |b| {
+        b.iter(|| {
+            block_on(async {
+                s.broadcast(n).await.unwrap();
+                assert_eq!(r1.recv().await.unwrap(), n);
+                n += 1;
+            })
+        })
+    });
+
+    let mut r2 = r1.clone();
+
+    c.bench_function("1 -> 2", |b| {
+        b.iter(|| {
+            block_on(async {
+                s.broadcast(n).await.unwrap();
+                assert_eq!(r1.recv().await.unwrap(), n);
+                assert_eq!(r2.recv().await.unwrap(), n);
+                n += 1;
+            })
+        })
+    });
+}
+
+criterion_group!(benches, broadcast_and_recv);
+criterion_main!(benches);


### PR DESCRIPTION
This removes the clone mentioned #18 for `try_recv` if we are the last receiver reading a message that would move the queue forward.

It also adds two benchmarks (one sender, one receiver) and (one sender two receivers) to measure this. The benchmark is not perfect as it uses simple_features as well as a copy-able payload (the best possible case for the old code) the results were still encouraging.

For 1->1 it showed a 1% drop in performance
for 1->2 it showed a 9% improvement in perforamcen

that seems worth it as we'll likely see much bigger improvements for more complex data structures that need to be cloned instead of copied.