### PR TITLE
Change Receiver::clone to truly duplicate a Receiver's state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,6 +548,44 @@ impl<T> Sender<T> {
     pub fn sender_count(&self) -> usize {
         self.inner.lock().unwrap().sender_count
     }
+
+    /// Produce a new Receiver for this channel.
+    ///
+    /// The new receiver starts with zero messages available.  This will not re-open the channel if
+    /// it was closed due to all receivers being dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_broadcast::{broadcast, RecvError};
+    ///
+    /// let (s, mut r1) = broadcast(2);
+    ///
+    /// assert_eq!(s.broadcast(1).await, Ok(None));
+    ///
+    /// let mut r2 = s.new_receiver();
+    ///
+    /// assert_eq!(s.broadcast(2).await, Ok(None));
+    /// drop(s);
+    ///
+    /// assert_eq!(r1.recv().await, Ok(1));
+    /// assert_eq!(r1.recv().await, Ok(2));
+    /// assert_eq!(r1.recv().await, Err(RecvError::Closed));
+    ///
+    /// assert_eq!(r2.recv().await, Ok(2));
+    /// assert_eq!(r2.recv().await, Err(RecvError::Closed));
+    /// # });
+    /// ```
+    pub fn new_receiver(&self) -> Receiver<T> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.receiver_count += 1;
+        Receiver {
+            inner: self.inner.clone(),
+            pos: inner.head_pos + inner.queue.len() as u64,
+            listener: None,
+        }
+    }
 }
 
 impl<T: Clone> Sender<T> {
@@ -1040,6 +1078,39 @@ impl<T: Clone> Receiver<T> {
         inner
             .try_recv_at(&mut self.pos)
             .map(|cow| cow.unwrap_or_else(T::clone))
+    }
+
+    /// Produce a new Sender for this channel.
+    ///
+    /// This will not re-open the channel if it was closed due to all senders being dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_broadcast::{broadcast, RecvError};
+    ///
+    /// let (s1, mut r) = broadcast(2);
+    ///
+    /// assert_eq!(s1.broadcast(1).await, Ok(None));
+    ///
+    /// let mut s2 = r.new_sender();
+    ///
+    /// assert_eq!(s2.broadcast(2).await, Ok(None));
+    /// drop(s1);
+    /// drop(s2);
+    ///
+    /// assert_eq!(r.recv().await, Ok(1));
+    /// assert_eq!(r.recv().await, Ok(2));
+    /// assert_eq!(r.recv().await, Err(RecvError::Closed));
+    /// # });
+    /// ```
+    pub fn new_sender(&self) -> Sender<T> {
+        self.inner.lock().unwrap().sender_count += 1;
+
+        Sender {
+            inner: self.inner.clone(),
+        }
     }
 
     /// Produce a new Receiver for this channel.


### PR DESCRIPTION
This changes Receiver::clone to do what you probably expect it to do: produce a Receiver with the same messages queued.