### PR TITLE
Use parking_lot RwLock instead of std::sync::Mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ name = "broadcast_bench"
 event-listener = "2.5.1"
 futures-core = "0.3.14"
 easy-parallel = "3.1.0"
+parking_lot = "0.11.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/broadcast_bench.rs
+++ b/benches/broadcast_bench.rs
@@ -27,6 +27,44 @@ pub fn broadcast_and_recv(c: &mut Criterion) {
             })
         })
     });
+
+    let mut r3 = r1.clone();
+    let mut r4 = r1.clone();
+
+    c.bench_function("1 -> 4", |b| {
+        b.iter(|| {
+            block_on(async {
+                s.broadcast(n).await.unwrap();
+                assert_eq!(r1.recv().await.unwrap(), n);
+                assert_eq!(r2.recv().await.unwrap(), n);
+                assert_eq!(r3.recv().await.unwrap(), n);
+                assert_eq!(r4.recv().await.unwrap(), n);
+                n += 1;
+            })
+        })
+    });
+
+    let mut r5 = r1.clone();
+    let mut r6 = r1.clone();
+    let mut r7 = r1.clone();
+    let mut r8 = r1.clone();
+
+    c.bench_function("1 -> 8", |b| {
+        b.iter(|| {
+            block_on(async {
+                s.broadcast(n).await.unwrap();
+                assert_eq!(r1.recv().await.unwrap(), n);
+                assert_eq!(r2.recv().await.unwrap(), n);
+                assert_eq!(r3.recv().await.unwrap(), n);
+                assert_eq!(r4.recv().await.unwrap(), n);
+                assert_eq!(r5.recv().await.unwrap(), n);
+                assert_eq!(r6.recv().await.unwrap(), n);
+                assert_eq!(r7.recv().await.unwrap(), n);
+                assert_eq!(r8.recv().await.unwrap(), n);
+                n += 1;
+            })
+        })
+    });
 }
 
 criterion_group!(benches, broadcast_and_recv);


### PR DESCRIPTION
Hi, benches show that it slightly reduces the performance in 1 -> 1 case, but in 1 -> n cases performance has increased by about 10-20%. The purpose of the broadcast channel is to handle 1 -> n cases well.

master results:

```
1 -> 1                  time:   [57.567 ns 57.669 ns 57.781 ns]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

1 -> 2                  time:   [109.41 ns 109.95 ns 110.76 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

1 -> 4                  time:   [162.51 ns 162.92 ns 163.40 ns]

1 -> 8                  time:   [263.26 ns 263.90 ns 264.67 ns]
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe
```

parking_lot RwLock result:

```
1 -> 1                  time:   [68.974 ns 69.136 ns 69.326 ns]
                        change: [+18.780% +19.893% +21.127%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

1 -> 2                  time:   [95.413 ns 95.889 ns 96.401 ns]
                        change: [-13.716% -13.242% -12.811%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

1 -> 4                  time:   [136.00 ns 136.32 ns 136.67 ns]
                        change: [-17.531% -16.911% -16.222%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

1 -> 8                  time:   [231.09 ns 233.31 ns 235.76 ns]
                        change: [-13.582% -12.924% -12.295%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```