### PR TITLE
Update lint name due to deprecation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //!
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
+#![warn(missing_docs, rustdoc::missing_doc_code_examples, unreachable_pub)]
 
 #[cfg(doctest)]
 mod doctests {


### PR DESCRIPTION
Update lint `missing_doc_code_examples` to `rustdoc::missing_doc_code_examples` due to deprecation