### PR TITLE
Use std RwLock instead of parking_lot.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ name = "broadcast_bench"
 [dependencies]
 event-listener = "2.5.2"
 futures-core = "0.3.21"
-parking_lot = "0.12.1"
 
 [dev-dependencies]
 criterion = "0.3.5"


### PR DESCRIPTION
Fixes #37.

After sync primitives (Mutex, RwLock, Condvar) from rust std library start use futex in */Linux systems, they become same or faster than parking_lot sync primitives. That the reason switch to std sync primitives.