### PR TITLE
`Sender::broadcast` now returns `Send<'static>`

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -288,3 +288,14 @@ fn inactive_drop() {
 
     assert!(s.is_closed())
 }
+
+#[test]
+#[ignore]
+fn keep_sender_and_send() {
+    // Compile-only test to ensure `Sender` and `Send` can be kept in the same place w/o running
+    // into self-reference issues.
+    let (s, _) = broadcast::<()>(1);
+
+    let f = s.broadcast(());
+    let _both = (s, f);
+}


### PR DESCRIPTION
The static lifetime allows the `Send` to be kept around in the same place/type as `Sender` w/o running into self-reference issues.

Since the inner struct is in an `Arc`, cloning is cheap and this change doesn't affect the performance of `Sender::broadcast`.

We could just drop the lifetime parameter entirely at this point but let's keep it for backwards compatibility.

Fixes #39.