### PR TITLE
Bump to event-listener v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ name = "broadcast_bench"
 [features]
 
 [dependencies]
-event-listener = "2.5.2"
+event-listener = "3"
+event-listener-strategy = "0.1.0"
 futures-core = "0.3.21"
 
 [dev-dependencies]


### PR DESCRIPTION
Testing to make sure that `event-listener v3.0.0` actually works before we release smol-rs/event-listener#58