### PR TITLE
Add poll_recv method to Receiver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1314,7 +1314,9 @@ impl<T: Clone> Receiver<T> {
     /// # Examples
     ///
     /// This example shows how the [`Receiver::poll_recv`] method can be used to allow a custom
-    /// stream implementation to internally make use of a [`Receiver`].
+    /// stream implementation to internally make use of a [`Receiver`]. This example implementation
+    /// differs from the stream implementation of [`Receiver`] because it returns an error if
+    /// the channel capacity overflows, which the built in [`Receiver`] stream doesn't do.
     ///
     /// ```
     /// use futures_core::Stream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1299,7 +1299,7 @@ impl<T: Clone> Receiver<T> {
         }
     }
 
-    /// A low level poll function that returns items of the same format handed back by
+    /// A low level poll method that returns items of the same format handed back by
     /// [`Receiver::recv()`] and [`Receiver::recv_direct()`]. This can be useful for building
     /// stream implementations which use a [`Receiver`] under the hood and want to know if the
     /// stream has overflowed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1303,6 +1303,9 @@ impl<T: Clone> Receiver<T> {
     /// [`Receiver::recv_direct()`], and can be useful for building stream implementations which
     /// use a [`Receiver`] under the hood and want to know if the stream has overflowed.
     ///
+    /// If the number of messages that have been sent has overflowed the channel capacity, an
+    /// [`OverflowError`] is returned containing the number of items that overflowed and were lost.
+    ///
     /// Prefer to use [`Receiver::recv()`] or [`Receiver::recv_direct()`] when otherwise possible.
     ///
     /// # Examples

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -297,7 +297,7 @@ fn poll_recv() {
     // A quick custom stream impl to demonstrate/test `poll_recv`.
     struct MyStream(Receiver<i32>);
     impl futures_core::Stream for MyStream {
-        type Item = Result<i32, RecvError>;
+        type Item = Result<i32, OverflowError>;
         fn poll_next(
             mut self: std::pin::Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
@@ -314,7 +314,7 @@ fn poll_recv() {
         s.broadcast(3).await.unwrap();
         s.broadcast(4).await.unwrap();
 
-        assert_eq!(stream.next().await.unwrap(), Err(RecvError::Overflowed(2)));
+        assert_eq!(stream.next().await.unwrap(), Err(OverflowError(2)));
         assert_eq!(stream.next().await.unwrap(), Ok(3));
         assert_eq!(stream.next().await.unwrap(), Ok(4));
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -297,7 +297,7 @@ fn poll_recv() {
     // A quick custom stream impl to demonstrate/test `poll_recv`.
     struct MyStream(Receiver<i32>);
     impl futures_core::Stream for MyStream {
-        type Item = Result<i32, OverflowError>;
+        type Item = Result<i32, RecvError>;
         fn poll_next(
             mut self: std::pin::Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
@@ -314,7 +314,7 @@ fn poll_recv() {
         s.broadcast(3).await.unwrap();
         s.broadcast(4).await.unwrap();
 
-        assert_eq!(stream.next().await.unwrap(), Err(OverflowError(2)));
+        assert_eq!(stream.next().await.unwrap(), Err(RecvError::Overflowed(2)));
         assert_eq!(stream.next().await.unwrap(), Ok(3));
         assert_eq!(stream.next().await.unwrap(), Ok(4));
 


### PR DESCRIPTION
This PR Adds a `poll_recv()` method to the `Receiver` type. It returns the same `Result<T,RecvError>` type that the `receiver.recv()` future returns (hence the name).

This method can be used when defining custom streams that internally make use of `async_broadcast` and want to know about whether the `async_broadcast` stream has overflowed or not.