### PR TITLE
v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.7.1
+
+- Add a `poll_recv()` method to the `Receiver` type. This allows for `Receiver`
+  to be used in `poll`-based contexts. (#56)
+
 # Version 0.7.0
 
 - **Breaking:** `Recv` and `Send` are now `!Unpin` to allow for future optimizations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-broadcast"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/smol-rs/async-broadcast"
 documentation = "https://docs.rs/async-broadcast"


### PR DESCRIPTION
- Add a `poll_recv()` method to the `Receiver` type. This allows for `Receiver` to be used in `poll`-based contexts. (#56)
