### PR TITLE
Specify MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/smol-rs/async-broadcast"
 documentation = "https://docs.rs/async-broadcast"
 description = "Async broadcast channels"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 keywords = []
 categories = []
 authors = [
@@ -14,6 +14,7 @@ authors = [
     "Yoshua Wuyts <yoshuawuyts@gmail.com>",
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
 ]
+
 
 [[bench]]
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/async-broadcast"
 description = "Async broadcast channels"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.60"
 keywords = []
 categories = []
 authors = [


### PR DESCRIPTION
We keep it the same as that of `smol`, in hopes of being reexported from it.
    
With clippy now part of the CI, it will check if we break MSRV.
