### PR TITLE
(breaking change) Add std and alloc features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ harness = false
 name = "broadcast_bench"
 
 [features]
+default = ["std"]
+alloc = []
+std = ["alloc"]
 
 [dependencies]
 event-listener = "5.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,9 @@
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
 
+#[cfg(any(not(feature = "std"), not(feature = "alloc"),))]
+compile_error! { "async-broadcast requires the 'std' and 'alloc' features to be enabled" }
+
 #[cfg(doctest)]
 mod doctests {
     doc_comment::doctest!("../README.md");


### PR DESCRIPTION
These features do nothing and raise a compiler error if disabled. However this enables us to disable these features in the future.
