### PR TITLE
Add `Sender::broadcast_blocking` and `Receiver::recv_blocking`

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -45,6 +45,23 @@ fn basic_async() {
     });
 }
 
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn basic_blocking() {
+    let (s, mut r) = broadcast(1);
+
+    s.broadcast_blocking(7).unwrap();
+    assert_eq!(r.try_recv(), Ok(7));
+
+    s.broadcast_blocking(8).unwrap();
+    assert_eq!(block_on(r.recv()), Ok(8));
+
+    block_on(s.broadcast(9)).unwrap();
+    assert_eq!(r.recv_blocking(), Ok(9));
+
+    assert_eq!(r.try_recv(), Err(TryRecvError::Empty));
+}
+
 #[test]
 fn parallel() {
     let (s1, mut r1) = broadcast(2);


### PR DESCRIPTION
Support blocking broadcast and receive using the `wait()` function from the `event-listener` crate

I'm unsure about calling `wait()` on `recv_direct()` and `broadcast_direct()` methods. I'm open to making adjustments.

Fixes #41