### PR TITLE
Use AtomicU64 instead of u64 for the position field in Receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-broadcast"
-version = "0.7.1"
+version = "0.8.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/smol-rs/async-broadcast"
 documentation = "https://docs.rs/async-broadcast"

--- a/benches/broadcast_bench.rs
+++ b/benches/broadcast_bench.rs
@@ -2,7 +2,7 @@ use async_broadcast::broadcast;
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures_lite::future::block_on;
 pub fn broadcast_and_recv(c: &mut Criterion) {
-    let (s, mut r1) = broadcast(1);
+    let (s, r1) = broadcast(1);
 
     let mut n = 0;
     c.bench_function("1 -> 1", |b| {
@@ -15,7 +15,7 @@ pub fn broadcast_and_recv(c: &mut Criterion) {
         })
     });
 
-    let mut r2 = r1.clone();
+    let r2 = r1.clone();
 
     c.bench_function("1 -> 2", |b| {
         b.iter(|| {
@@ -28,8 +28,8 @@ pub fn broadcast_and_recv(c: &mut Criterion) {
         })
     });
 
-    let mut r3 = r1.clone();
-    let mut r4 = r1.clone();
+    let r3 = r1.clone();
+    let r4 = r1.clone();
 
     c.bench_function("1 -> 4", |b| {
         b.iter(|| {
@@ -44,10 +44,10 @@ pub fn broadcast_and_recv(c: &mut Criterion) {
         })
     });
 
-    let mut r5 = r1.clone();
-    let mut r6 = r1.clone();
-    let mut r7 = r1.clone();
-    let mut r8 = r1.clone();
+    let r5 = r1.clone();
+    let r6 = r1.clone();
+    let r7 = r1.clone();
+    let r8 = r1.clone();
 
     c.bench_function("1 -> 8", |b| {
         b.iter(|| {

--- a/benches/broadcast_bench.rs
+++ b/benches/broadcast_bench.rs
@@ -65,6 +65,40 @@ pub fn broadcast_and_recv(c: &mut Criterion) {
             })
         })
     });
+
+    let r9 = r1.clone();
+    let r10 = r1.clone();
+    let r11 = r1.clone();
+    let r12 = r1.clone();
+    let r13 = r1.clone();
+    let r14 = r1.clone();
+    let r15 = r1.clone();
+    let r16 = r1.clone();
+
+    c.bench_function("1 -> 16", |b| {
+        b.iter(|| {
+            block_on(async {
+                s.broadcast(n).await.unwrap();
+                assert_eq!(r1.recv().await.unwrap(), n);
+                assert_eq!(r2.recv().await.unwrap(), n);
+                assert_eq!(r3.recv().await.unwrap(), n);
+                assert_eq!(r4.recv().await.unwrap(), n);
+                assert_eq!(r5.recv().await.unwrap(), n);
+                assert_eq!(r6.recv().await.unwrap(), n);
+                assert_eq!(r7.recv().await.unwrap(), n);
+                assert_eq!(r8.recv().await.unwrap(), n);
+                assert_eq!(r9.recv().await.unwrap(), n);
+                assert_eq!(r10.recv().await.unwrap(), n);
+                assert_eq!(r11.recv().await.unwrap(), n);
+                assert_eq!(r12.recv().await.unwrap(), n);
+                assert_eq!(r13.recv().await.unwrap(), n);
+                assert_eq!(r14.recv().await.unwrap(), n);
+                assert_eq!(r15.recv().await.unwrap(), n);
+                assert_eq!(r16.recv().await.unwrap(), n);
+                n += 1;
+            })
+        })
+    });
 }
 
 criterion_group!(benches, broadcast_and_recv);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,14 +12,14 @@ fn ms(ms: u64) -> Duration {
 
 #[test]
 fn basic_sync() {
-    let (s, mut r1) = broadcast(10);
-    let mut r2 = r1.clone();
+    let (s, r1) = broadcast(10);
+    let r2 = r1.clone();
 
     s.try_broadcast(7).unwrap();
     assert_eq!(r1.try_recv().unwrap(), 7);
     assert_eq!(r2.try_recv().unwrap(), 7);
 
-    let mut r3 = r1.clone();
+    let r3 = r1.clone();
     s.try_broadcast(8).unwrap();
     assert_eq!(r1.try_recv().unwrap(), 8);
     assert_eq!(r2.try_recv().unwrap(), 8);
@@ -48,7 +48,7 @@ fn basic_async() {
 #[cfg(not(target_family = "wasm"))]
 #[test]
 fn basic_blocking() {
-    let (s, mut r) = broadcast(1);
+    let (s, r) = broadcast(1);
 
     s.broadcast_blocking(7).unwrap();
     assert_eq!(r.try_recv(), Ok(7));
@@ -64,9 +64,9 @@ fn basic_blocking() {
 
 #[test]
 fn parallel() {
-    let (s1, mut r1) = broadcast(2);
+    let (s1, r1) = broadcast(2);
     let s2 = s1.clone();
-    let mut r2 = r1.clone();
+    let r2 = r1.clone();
 
     let (sender_sync_send, sender_sync_recv) = mpsc::channel();
     let (receiver_sync_send, receiver_sync_recv) = mpsc::channel();
@@ -162,9 +162,9 @@ fn parallel_async() {
 #[test]
 fn channel_shrink() {
     let (s1, mut r1) = broadcast(4);
-    let mut r2 = r1.clone();
-    let mut r3 = r1.clone();
-    let mut r4 = r1.clone();
+    let r2 = r1.clone();
+    let r3 = r1.clone();
+    let r4 = r1.clone();
 
     s1.try_broadcast(1).unwrap();
     s1.try_broadcast(2).unwrap();
@@ -287,7 +287,7 @@ fn open_channel() {
                 sender_sync_send.send(()).unwrap();
                 receiver_sync_recv.recv().unwrap();
 
-                let mut r = inactive.activate();
+                let r = inactive.activate();
                 assert_eq!(r.recv().await.unwrap(), 9);
                 assert_eq!(r.recv().await.unwrap(), 10);
             })


### PR DESCRIPTION
The `recv()`, `recv_direct()`, `recv_blocking()`, and `try_recv()` methods currently require `&mut self` to modify the value of the `position` field. By using AtomicU64 for the `position` field eliminates the need for mutability.

Regarding performance, it's worth noting that on most processor architectures, there is no much difference between an atomic store and a regular non-atomic store (source: [1](https://marabos.nl/atomics/memory-ordering.html#the-memory-model), [2](https://marabos.nl/atomics/hardware.html#load-store-ops)). 

Additionally, Atomic operations are generally not as expensive as mutexes, as mutexes themselves are implemented using atomic operations but with additional overhead for locking.

**This PR has breaking API changes.**

Fixes issue #66